### PR TITLE
Replaces the dummy-typedef with a dummy-structure.

### DIFF
--- a/pclTypes.hpp
+++ b/pclTypes.hpp
@@ -6,8 +6,14 @@
 
 namespace pcl
 {
-    /* NOTE: This is a helper to force typelib to parse PCLPointCloud2 when parsing this header */
-    typedef pcl::PCLPointCloud2 _PCLPointCloud2;
+    // NOTE: This is a helper to force typelib to parse PCLPointCloud2 when parsing this header.
+    //typedef pcl::PCLPointCloud2 _PCLPointCloud2;
+    // NOTE: typedef caused the following error
+    // tools/utilrb/lib/utilrb/module/const_defined_here_p.rb:9:in `const_defined?': 
+    //  wrong constant name _PCLPointCloud2 (NameError)
+    struct Dummy {
+        PCLPointCloud2 pc2;
+    };
 }
 
 namespace aggregator


### PR DESCRIPTION
The dummy-typedef caused the following error:
tools/utilrb/lib/utilrb/module/const_defined_here_p.rb:9:
in `const_defined?': wrong constant name _PCLPointCloud2 (NameError)