### PR TITLE
force orogen to use our header for pcl::PointCloud2

### DIFF
--- a/PCLPointCloud2WithTimestamp.hpp
+++ b/PCLPointCloud2WithTimestamp.hpp
@@ -1,14 +1,8 @@
-#ifndef __PCL_TYPES_HPP__
-#define __PCL_TYPES_HPP__
+#ifndef PCL_AGGREGATOR_TIMESTAMPING_HPP
+#define PCL_AGGREGATOR_TIMESTAMPING_HPP
 
 #include <base/Time.hpp>
 #include <pcl/PCLPointCloud2.h>
-
-namespace pcl
-{
-    /* NOTE: This is a helper to force typelib to parse PCLPointCloud2 when parsing this header */
-    typedef pcl::PCLPointCloud2 _PCLPointCloud2;
-}
 
 namespace aggregator
 {

--- a/pcl.orogen
+++ b/pcl.orogen
@@ -4,8 +4,18 @@ version "0.1"
 using_library 'pcl_common-1.7'
 
 import_types_from "base"
-import_types_from "pclTypes.hpp"
+
+# We want to export the PointCloud2 type, but trick oroGen into using a
+# different header so that the determineTimestap function is present (for the
+# benefit of the aggregator)
+#
+# Import both headers normally, and later force the orogen_include metadata to
+# what we desire
+import_types_from "pcl/PCLPointCloud2.h"
+import_types_from "PCLPointCloud2WithTimestamp.hpp"
 
 typekit do
+    find_type('/pcl/PCLPointCloud2').
+        metadata.set('orogen_include', 'pcl:pcl/PCLPointCloud2WithTimestamp.hpp')
     export_types '/pcl/PCLPointCloud2'
 end


### PR DESCRIPTION
This ensures that components that would use the stream aligner
use the timestamp directly from the type.