### PR TITLE
added export of pcl::PolygonMesh type

### DIFF
--- a/PolygonMeshWithTimestamp.hpp
+++ b/PolygonMeshWithTimestamp.hpp
@@ -1,0 +1,20 @@
+#ifndef PCL_POLYGON_MESH_AGGREGATOR_TIMESTAMPING_HPP
+#define PCL_POLYGON_MESH_AGGREGATOR_TIMESTAMPING_HPP
+
+#include <base/Time.hpp>
+#include <pcl/PolygonMesh.h>
+
+namespace aggregator
+{
+
+/**
+ * Allows the aggregator and the transformer to determine the timestamp of the PolygonMesh type.
+ */
+inline base::Time determineTimestamp(const ::pcl::PolygonMesh& type)
+{
+    return base::Time::fromMicroseconds(type.header.stamp);
+}
+
+}
+
+#endif

--- a/pcl.orogen
+++ b/pcl.orogen
@@ -14,8 +14,28 @@ import_types_from "base"
 import_types_from "pcl/PCLPointCloud2.h"
 import_types_from "PCLPointCloud2WithTimestamp.hpp"
 
+# We have to create a wrapper class for pcl::Vertices, since orogen can't handle that
+# the struct (Vertices) and it's member (vertices) have the same name.
+# (We have to include boost/shared_ptr.hpp because it is missing in the pcl/Vertices header.
+# It is fixed in PCL 1.8.1 onwards and can be removed as soon as they become the default version.)
+import_types_from "wrappers/PCLVertices.hpp"
+typekit.opaque_type '/pcl/Vertices', '/wrappers/PCLVertices', :includes => ['boost/shared_ptr.hpp', 'pcl/Vertices.h']
+
+# We want to export the PolygonMesh type, but trick oroGen into using a
+# different header so that the determineTimestap function is present (for the
+# benefit of the aggregator)
+#
+# Import both headers normally, and later force the orogen_include metadata to
+# what we desire
+import_types_from "pcl/PolygonMesh.h"
+import_types_from "PolygonMeshWithTimestamp.hpp"
+
 typekit do
     find_type('/pcl/PCLPointCloud2').
         metadata.set('orogen_include', 'pcl:pcl/PCLPointCloud2WithTimestamp.hpp')
     export_types '/pcl/PCLPointCloud2'
+
+    find_type('/pcl/PolygonMesh').
+        metadata.set('orogen_include', 'pcl:pcl/PolygonMeshWithTimestamp.hpp')
+    export_types '/pcl/PolygonMesh'
 end

--- a/typekit/Opaques.cpp
+++ b/typekit/Opaques.cpp
@@ -1,0 +1,23 @@
+/* Generated from orogen/lib/orogen/templates/typekit/Opaques.cpp */
+
+#include <pcl/typekit/OpaqueTypes.hpp>
+#include <pcl/typekit/Opaques.hpp>
+
+    /** Returns the intermediate value that is contained in \c real_type */
+    /** Stores \c intermediate into \c real_type. \c intermediate is owned by \c
+     * real_type afterwards. */
+    /** Release ownership of \c real_type on the corresponding intermediate
+     * pointer.
+     */
+
+
+void orogen_typekits::toIntermediate(::wrappers::PCLVertices& intermediate, ::pcl::Vertices const& real_type)
+{
+    intermediate.vertices = real_type.vertices;
+}
+
+void orogen_typekits::fromIntermediate(::pcl::Vertices& real_type, ::wrappers::PCLVertices const& intermediate)
+{
+    real_type.vertices = intermediate.vertices;
+}
+

--- a/typekit/Opaques.hpp
+++ b/typekit/Opaques.hpp
@@ -1,0 +1,20 @@
+/* Generated from orogen/lib/orogen/templates/typekit/Opaques.hpp */
+
+#ifndef __OROGEN_GENERATED_pcl_USER_MARSHALLING_HH
+#define __OROGEN_GENERATED_pcl_USER_MARSHALLING_HH
+
+#include <pcl/typekit/OpaqueFwd.hpp>
+
+namespace orogen_typekits
+{
+    
+    /** Converts \c real_type into \c intermediate */
+    void toIntermediate(::wrappers::PCLVertices& intermediate, ::pcl::Vertices const& real_type);
+    /** Converts \c intermediate into \c real_type */
+    void fromIntermediate(::pcl::Vertices& real_type, ::wrappers::PCLVertices const& intermediate);
+        
+    
+}
+
+#endif
+

--- a/wrappers/PCLVertices.hpp
+++ b/wrappers/PCLVertices.hpp
@@ -1,0 +1,15 @@
+#ifndef PCL_VERTICES_WRAPPER_HPP
+#define PCL_VERTICES_WRAPPER_HPP
+
+#include <vector>
+#include <stdint.h>
+
+namespace wrappers
+{
+    struct PCLVertices
+    {
+        std::vector<uint32_t> vertices;
+    };
+}
+
+#endif


### PR DESCRIPTION
I had to add an opaque type for pcl::Vertices since the generated corba transport types apparently can't handle if a class it's member are named equally:

``` 
slam/orogen/pcl/.orogen/typekit/transports/corba/pclTypes.idl:24: Instance identifier 'vertices' clashes with name of enclosing scope 'Vertices'
slam/orogen/pcl/.orogen/typekit/transports/corba/pclTypes.idl:23:  ('Vertices' declared here)
 ```